### PR TITLE
Fix lineage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 The `ncov_parser` package provides a suite of tools to parse the files generated
 in the Nextflow workflow and provide a QC summary file.  The package requires
 several files including:
-* <sample>.variants.tsv/<sample>.pass.vcf
+* <sample>.variants.tsv
+* <sample>.variants.norm.vcf
+* <sample>.pass.vcf
 * <sample>.per_base_coverage.bed
 * <sample>.primertrimmed.consensus.fa
+* <sample>.consensus.fasta
 * alleles.tsv
 
 An optional metadata file with qPCR ct and collection date values can be

--- a/data/test_lineages.csv
+++ b/data/test_lineages.csv
@@ -1,4 +1,4 @@
 taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,version,pangolin_version,pangoLEARN_version,pango_version,status,note
-sampleA3,B.1.1.7,0.0,1.0,cB.1.1.7,0.782600,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 18; Ref alleles 3; Amb alleles 0
+sampleA,B.1.1.7,0.0,1.0,cB.1.1.7,0.782600,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 18; Ref alleles 3; Amb alleles 0
 sampleB,B.1.1.7,0.0,1.0,cB.1.1.7,0.652200,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 15; Ref alleles 3; Amb alleles 3
 sampleC,B.1.1.7,0.0,1.0,cB.1.1.7,0.782600,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 18; Ref alleles 3; Amb alleles 0

--- a/data/test_lineages.csv
+++ b/data/test_lineages.csv
@@ -1,0 +1,4 @@
+taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,version,pangolin_version,pangoLEARN_version,pango_version,status,note
+sampleA3,B.1.1.7,0.0,1.0,cB.1.1.7,0.782600,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 18; Ref alleles 3; Amb alleles 0
+sampleB,B.1.1.7,0.0,1.0,cB.1.1.7,0.652200,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 15; Ref alleles 3; Amb alleles 3
+sampleC,B.1.1.7,0.0,1.0,cB.1.1.7,0.782600,0.130400,PLEARN-v1.2.6,3.0.3,2021-05-27,v1.2.6,passed_qc,scorpio call: Alt alleles 18; Ref alleles 3; Amb alleles 0

--- a/ncov/parser/Lineage.py
+++ b/ncov/parser/Lineage.py
@@ -37,11 +37,16 @@ class Lineage():
         """
         Return the notes that pangolin added to the lineage assignment
         """
-        n = row['note']
+        #n = row['note']
+        n = ' '.split(row['note'])
         if n is None or n == "":
             return "none"
         else:
-            return n.replace(" ", "_")
+            alt = re.sub(';', '', n[4])
+            ref = re.sub(';', '', n[7])
+            amb = n[-1]
+            return '/'.join([alt, ref, amb])
+            #return n.replace(" ", "_")
     
     def create_lineage_dictionary(self):
         """

--- a/ncov/parser/Lineage.py
+++ b/ncov/parser/Lineage.py
@@ -37,14 +37,14 @@ class Lineage():
         """
         Return the notes that pangolin added to the lineage assignment
         """
-        #n = row['note']
-        n = ' '.split(row['note'])
+        n = row['note']
         if n is None or n == "":
             return "none"
         else:
-            alt = re.sub(';', '', n[4])
-            ref = re.sub(';', '', n[7])
-            amb = n[-1]
+            n_dict = n.split(' ')
+            alt = re.sub(';', '', n_dict[4])
+            ref = re.sub(';', '', n_dict[7])
+            amb = n_dict[-1]
             return '/'.join([alt, ref, amb])
             #return n.replace(" ", "_")
     

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ncov_parser",
-    version="0.6.5",
+    version="0.6.6",
     author="Richard J. de Borja",
     author_email="richard.deborja@oicr.on.ca",
     description="A nCoV package for parsing analysis files",

--- a/tests/test_Lineage.py
+++ b/tests/test_Lineage.py
@@ -5,14 +5,15 @@ Suite of tests for the Consensus module
 import unittest
 import ncov.parser
 
-test_lineage = ncov.parser.Lineage(file='data/sample_lineages.csv')
+test_lineage = ncov.parser.Lineage(file='data/test_lineages.csv')
 
 
 class LineageTest(unittest.TestCase):
     def test_create_lineage_dictionary(self):
         lineage_dict = test_lineage.create_lineage_dictionary()
-        self.assertEqual(lineage_dict['sampleA']['lineage'], 'B.1.1.43')
-        self.assertEqual(lineage_dict['sampleB']['lineage'], 'B.1.36')
+        self.assertEqual(lineage_dict['sampleA']['lineage'], 'B.1.1.7')
+        self.assertEqual(lineage_dict['sampleA']['notes'], '18/3/0')
+        self.assertEqual(lineage_dict['sampleB']['lineage'], 'B.1.1.7')
         self.assertEqual(lineage_dict['sampleC']['lineage'], 'B.1.1.7')
     def test_get_sample_name(self):
         sample_row = {'taxon' : 'sampleA/ARTIC/nanopolish',

--- a/tests/test_Lineage.py
+++ b/tests/test_Lineage.py
@@ -11,9 +11,9 @@ test_lineage = ncov.parser.Lineage(file='data/sample_lineages.csv')
 class LineageTest(unittest.TestCase):
     def test_create_lineage_dictionary(self):
         lineage_dict = test_lineage.create_lineage_dictionary()
-        self.assertEqual(lineage_dict['sampleA'], 'B.1.1.43')
-        self.assertEqual(lineage_dict['sampleB'], 'B.1.36')
-        self.assertEqual(lineage_dict['sampleC'], 'B.1.1.7')
+        self.assertEqual(lineage_dict['sampleA']['lineage'], 'B.1.1.43')
+        self.assertEqual(lineage_dict['sampleB']['lineage'], 'B.1.36')
+        self.assertEqual(lineage_dict['sampleC']['lineage'], 'B.1.1.7')
     def test_get_sample_name(self):
         sample_row = {'taxon' : 'sampleA/ARTIC/nanopolish',
                       'lineage' : 'B.1.1.43',


### PR DESCRIPTION
Pangolin 3.0.3 has a different `notes` column from version 2.4.2.  The parser uses the alt/ref/amb count found in the `notes` field.