### PR TITLE
Issue 85 from ncov-tools

### DIFF
--- a/ncov/parser/Lineage.py
+++ b/ncov/parser/Lineage.py
@@ -38,9 +38,7 @@ class Lineage():
         Return the notes that pangolin added to the lineage assignment
         """
         n = row['note']
-        if n is None or n == "":
-            return "none"
-        else:
+        if n.startswith('scorpio call'):
             n_dict = n.split(' ')
             alt = re.sub(';', '', n_dict[4])
             ref = re.sub(';', '', n_dict[7])
@@ -48,6 +46,9 @@ class Lineage():
             tag = 'alt/ref/amb:'
             value = '/'.join([alt, ref, amb])
             return ''.join([tag, value])
+        #if n is None or n == "" or n.startswith('Assigned'):
+        else:
+            return "none"
 
 
     def get_scorpio_call(self, row):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ncov_parser",
-    version="0.6.7",
+    version="0.6.8",
     author="Richard J. de Borja",
     author_email="richard.deborja@oicr.on.ca",
     description="A nCoV package for parsing analysis files",


### PR DESCRIPTION
Lineage parser causes `get_qc.py` to return `none` in the lineage fields.