### PR TITLE
Add support for primer name prefix

### DIFF
--- a/bin/primers_to_amplicons.py
+++ b/bin/primers_to_amplicons.py
@@ -14,6 +14,8 @@ parser.add_argument('-o', '--output', default='out.bed',
                     help='filename to write BED to')
 parser.add_argument('--bed_type', default='unique_amplicons',
                     help='type of BED to produce (e.g. full, no_primers, unique-amplicons')
+parser.add_argument('--primer_prefix', default='nCoV-2019',
+                    help='the primer name prefix used in the BED file (default: nCoV-2019)')
 if len(sys.argv) <= 1:
     parser.print_help(sys.stderr)
     sys.exit('Invalid number of arguments')
@@ -23,7 +25,8 @@ primers = pr.read_bed_file(args.primers)
 primer_pairs = pr.create_primer_pairs(primers=primers)
 amplicon_ranges = pr.create_amplicons(primer_pairs=primer_pairs,
                                       offset=args.offset,
-                                      type=args.bed_type)
+                                      type=args.bed_type,
+                                      prefix=args.primer_prefix)
 
 with open(args.output, 'w') as file_o:
     for line in amplicon_ranges:

--- a/ncov/parser/primers.py
+++ b/ncov/parser/primers.py
@@ -72,7 +72,7 @@ def create_primer_pairs(primers, left='_LEFT.*', right='_RIGHT.*'):
     return primer_pairs
 
 
-def create_amplicons(primer_pairs, offset=0, type='unique_amplicons'):
+def create_amplicons(primer_pairs, offset=0, type='unique_amplicons', prefix='nCoV-2019'):
     '''
     Create an array of BED regions as either full including primers, with no
     primers included, or as unique amplicons without overlaps.
@@ -92,9 +92,9 @@ def create_amplicons(primer_pairs, offset=0, type='unique_amplicons'):
     amplicons = list()
     for index in range(0, len(primer_pairs)):
         amplicon_id = index + 1
-        primer_name = f'nCoV-2019_{amplicon_id}'
-        previous_primer_name = f'nCoV-2019_{amplicon_id-1}'
-        next_primer_name = f'nCoV-2019_{amplicon_id + 1}'
+        primer_name = f'{prefix}_{amplicon_id}'
+        previous_primer_name = f'{prefix}_{amplicon_id-1}'
+        next_primer_name = f'{prefix}_{amplicon_id + 1}'
         if type == 'full':
             start = int(primer_pairs[primer_name]['left_start'])
             end = int(primer_pairs[primer_name]['right_end'])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ncov_parser",
-    version="0.6.8",
+    version="0.6.9",
     author="Richard J. de Borja",
     author_email="richard.deborja@oicr.on.ca",
     description="A nCoV package for parsing analysis files",


### PR DESCRIPTION
With the update to ARTIC primer schemes (V4), the hard coded primer prefix name was updated as a configurable parameter.